### PR TITLE
docs: Update model user tutorial links

### DIFF
--- a/docs/key_concepts.md
+++ b/docs/key_concepts.md
@@ -21,4 +21,4 @@ The model is served by a [gRPC](https://grpc.io) server that can run as is or in
 
 [This example of a client](https://github.com/caikit/caikit/blob/main/examples/text-sentiment/client.py) is a simple Python CLI that calls the model and queries it for sentiment analysis on two different pieces of text. The client also references the module configuration.
 
-Check out the full [Text Sentiment example](https://github.com/caikit/caikit/tree/main/examples/text-sentiment) or the [model user tutorial](./docs/tutorial_appdev.md) to understand how to load and infer a model using Caikit.
+Check out the full [Text Sentiment example](https://github.com/caikit/caikit/tree/main/examples/text-sentiment) or the [model user tutorial](tutorial_appdev.md) to understand how to load and infer a model using Caikit.

--- a/index.md
+++ b/index.md
@@ -16,4 +16,4 @@ Caikit's purpose is twofold:
 
 Simply put, Caikit makes it easy for you to implement and manage AI models in your apps, so you can focus on new development instead of maintenance.
 
-Curious to learn more? Check out our [model user tutorial]({{ site.baseurl }}{% link docs/tutorial_appdev.md %}) or [browse our API documentation](https://caikit.readthedocs.io/en/latest/index.html).
+Curious to learn more? Check out our [model user tutorial]({{ site.baseurl }}{% link tutorial_appdev.md %}) or [browse our API documentation](https://caikit.readthedocs.io/en/latest/index.html).


### PR DESCRIPTION
<img width="928" alt="image" src="https://github.com/caikit/website/assets/12246093/63e8b09f-2ee9-4d42-9a65-22d7551b8919">




https://caikit.github.io/website/website/docs/tutorial_appdev.html

<img width="595" alt="image" src="https://github.com/caikit/website/assets/12246093/80d02c1c-69cf-4ae0-b5d4-1732c247375e">

---

Similarly, the link at the bottom of the "Key concepts" page:

<img width="958" alt="image" src="https://github.com/caikit/website/assets/12246093/99a16d75-78a2-4a03-b2f7-209513b3c4e7">

--> `404`